### PR TITLE
Colorbars: Force cref closer to center of colorbar

### DIFF
--- a/tripyview/sub_plot.py
+++ b/tripyview/sub_plot.py
@@ -1577,10 +1577,19 @@ def do_setupcinfo(cinfo, data, do_rescale, mesh=None, tri=None, do_vec=False,
                 if cref==0.0: 
                     cinfo['cref'] = cref
                 else:
+                    # chose cref as center between cmin and cmax and round as coarsely as possible without
+                    # 1. rounded value lying outside ]cmin, cmax[ (tolfac=1)
+                    # 2. rounded value lying too far away from the middle (tolfac < 1)
+                    # cref will be forced to lie in area maked with "+"
+                    # cmin -----------++++++++++++++ ccenter ++++++++++++++----------- cmax
+                    #                |------ tolfac * (cmax - cmin) -------|
+                    ccenter = (cinfo['cmax'] + cinfo['cmin'])/2
+                    tolfac = 0.5 # tolfac=1 --> accept every cref that is between cmax and cmin. tolfac<1 --> cref closer to center
+                    ctolerance = tolfac * (cinfo['cmax'] - cinfo['cmin'])/2
                     while True:
                         new_cref = np.around(cref, -np.int32(np.floor(np.log10(np.abs(cref)))-dez) )
                         #print(cref, new_cref, cinfo['cmin'], cinfo['cmax'])
-                        if new_cref>cinfo['cmin'] and new_cref<cinfo['cmax']:
+                        if new_cref>(ccenter - ctolerance) and new_cref<(ccenter + ctolerance):
                             break
                         else: 
                             dez=dez+1


### PR DESCRIPTION
Modify rounding of cref for non-log plots.
Before it could happen in some cases that cref lies at edge of colorbar range.
--> This would cause loss of color information

Example case: salinity between 29.8 psu and 38.9 psu --> cref should be at 34.35 psu (middle).
Without changes it is rounded to 30 (loop exits in first iteration)
With changes it is now forced to round to 34 --> closer to middle


I think the cases where the original problem arises are when cref is not zero (i.e. anomaly plots are not affected) and when cmin and cmax
- are in the same order of magnitude and
- if their first differing digits differ by exactly 1 and
- if both first digits after their first differing digits are 'close' to 0 (periodically, e.g. 8,9,0,1)


### Examples using hslice template for some sea surface salinity field

Before change
![hslice_sss_y1920-1921](https://github.com/FESOM/tripyview/assets/107220804/819f8fbd-26b1-4cf3-a509-4634ff30297f)


After change
![hslice_sss_y1920-1921 improved-cbar](https://github.com/FESOM/tripyview/assets/107220804/fd5b40ef-127c-433a-9af2-1f448a9a6932)