### PR TITLE
Fix IndexError: Make cb_label right length

### DIFF
--- a/tripyview/sub_plot.py
+++ b/tripyview/sub_plot.py
@@ -350,7 +350,7 @@ def plot_hslice(mesh                   ,
         if not isinstance(streaml_dat, list): streaml_dat = [streaml_dat]
     ndat = len(data)
     
-    if not isinstance(cb_label, list): cb_label=[cb_label]
+    if not isinstance(cb_label, list): cb_label = [cb_label] * len(data)
     
     #___________________________________________________________________________
     # --> create projection


### PR DESCRIPTION
I think cb_label needs to be as long as number of plot panels otherwise one gets list index out of range for cb_label[cb_plt_idx[ii_valid]-1]

Maybe something similar needs to be done with streaml_dat in the line above?
I just tested this for my case:

I noticed the problem when using the hslice template to create a plot with one input path and one reference path. In the template `cb_label` is set to `None`, so `cb_label` would be later set to `[None]` which is a problem if the second plot panel tries to `do_cbar` and access the second element of `cb_label`.