### PR TITLE
Separate directories

### DIFF
--- a/tripyview/sub_tripyrun.py
+++ b/tripyview/sub_tripyrun.py
@@ -128,6 +128,9 @@ def tripyrun():
     #____DICTIONARY CONTENT_____________________________________________________
     # name of workflow runs --> also folder name 
     tripyrun_name = yaml_settings['tripyrun_name']
+    append_run_name_to_save_path = yaml_settings.get("append_run_name_to_save_path", True)  # NOTE(PG): Preserve current behaviour
+    notebook_dir = yaml_settings.get("notebook_dir")
+    figure_dir = yaml_settings.get("figure_dir")
 
     # setup data input paths & input names
     input_paths = yaml_settings['input_paths']
@@ -141,7 +144,10 @@ def tripyrun():
     
     # setup save path    
     if 'save_path' in yaml_settings: 
-        save_path = f"{yaml_settings['save_path']}/{tripyrun_name}"
+        if append_run_name_to_save_path:
+            save_path = f"{yaml_settings['save_path']}/{tripyrun_name}"
+        else:
+            save_path = yaml_settings['save_path']
     else:
         save_path = os.path.join(pkg_path, f"Results/{tripyrun_name}") 
     save_path = os.path.expanduser(save_path)
@@ -156,8 +162,8 @@ def tripyrun():
     yaml_settings['do_papermill']      = True
     
     yaml_settings['save_path']         = save_path
-    yaml_settings['tripyrun_spath_nb' ]= os.path.join(save_path, "notebooks")
-    yaml_settings['tripyrun_spath_fig']= os.path.join(save_path, "figures")  
+    yaml_settings['tripyrun_spath_nb' ]= notebook_dir or os.path.join(save_path, "notebooks")
+    yaml_settings['tripyrun_spath_fig']= figure_dir or os.path.join(save_path, "figures")  
     
     # papermiller imports python None variable declaration as "None" string this causes 
     # trouble in the if VAR is None: comparison:


### PR DESCRIPTION
Closes #206 

This adds some new flags you can set in the main YAML file, but if nothing is set, the current behavior is preserved. 

### AI Summary
This pull request includes several changes to the `tripyview/sub_tripyrun.py` file to enhance the flexibility of the `tripyrun` function. The changes introduce new configuration options for customizing the save paths for notebooks and figures, and provide an option to control whether the run name is appended to the save path.

Enhancements to `tripyrun` function:

* Added `append_run_name_to_save_path` option to control whether the run name is appended to the save path. [[1]](diffhunk://#diff-8911e3c65354cb81110574f508348550efb537ce08d4de8bcb4cf56fcfad7471R131-R133) [[2]](diffhunk://#diff-8911e3c65354cb81110574f508348550efb537ce08d4de8bcb4cf56fcfad7471R147-R150)
* Introduced `notebook_dir` and `figure_dir` options to allow custom directory paths for notebooks and figures. [[1]](diffhunk://#diff-8911e3c65354cb81110574f508348550efb537ce08d4de8bcb4cf56fcfad7471R131-R133) [[2]](diffhunk://#diff-8911e3c65354cb81110574f508348550efb537ce08d4de8bcb4cf56fcfad7471L159-R166)