### PR TITLE
tripyrun/papermill: Ignore TemplateNotebook Kernel

### DIFF
--- a/tripyview/sub_tripyrundriver.py
+++ b/tripyview/sub_tripyrundriver.py
@@ -118,7 +118,8 @@ def exec_papermill(webpage, cnt, params_vname, exec_template='hslice'):
         pm.execute_notebook(f"{templates_nb_path}/template_{exec_template}.ipynb",
                             os.path.join(params_vname['tripyrun_spath_nb'], save_fname_nb),
                             parameters=params_vname,
-                            nest_asyncio=True,)
+                            nest_asyncio=True,
+                            kernel_name="python3",)
         print('Data found')
     except pm.PapermillExecutionError as e:
         print(f"Error while running Notebook: {e}")


### PR DESCRIPTION
Use default Kernel "python3" instead.

This should fix issues like `Unexpected Error: No such kernel named py39_new` when running `tripyrun`.
Error was raised as papermill by default tries executing the notebooks using the kernel specified in the notebook metadata.

This fix tells papermill to use the Kernel called "python3" and ignore notebook metadata.

Details:
Once any conda environment is activated it seems that the kernel "python3" is associated with the activated conda environment independent of the name of the conda environment.

Only if no environment is activated "python3" is the name of the kernel associated with the default e.g. Levante python env.

This can be verified by running `jupyter kernelspec list` (before/after activating conda env)

Only tested on Levante with python 3.12