### PR TITLE
Update all Notebooks to Suppress Tripyrun Parsing Error

### DIFF
--- a/templates_notebooks/template_bias_heatmap.ipynb
+++ b/templates_notebooks/template_bias_heatmap.ipynb
@@ -58,7 +58,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 1    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 1    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 250  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_hmesh.ipynb
+++ b/templates_notebooks/template_hmesh.ipynb
@@ -71,7 +71,7 @@
     "do_papermill      = False\n",
     "do_parallel       = False\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_hovm.ipynb
+++ b/templates_notebooks/template_hovm.ipynb
@@ -66,7 +66,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_hovm_clim.ipynb
+++ b/templates_notebooks/template_hovm_clim.ipynb
@@ -63,7 +63,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_hquiver.ipynb
+++ b/templates_notebooks/template_hquiver.ipynb
@@ -71,7 +71,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_hslice.ipynb
+++ b/templates_notebooks/template_hslice.ipynb
@@ -72,7 +72,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_hslice_channel.ipynb
+++ b/templates_notebooks/template_hslice_channel.ipynb
@@ -55,7 +55,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_hslice_clim.ipynb
+++ b/templates_notebooks/template_hslice_clim.ipynb
@@ -62,7 +62,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_hslice_isotdep.ipynb
+++ b/templates_notebooks/template_hslice_isotdep.ipynb
@@ -71,7 +71,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_hslice_neverworld2.ipynb
+++ b/templates_notebooks/template_hslice_neverworld2.ipynb
@@ -46,7 +46,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_hslice_quiver.ipynb
+++ b/templates_notebooks/template_hslice_quiver.ipynb
@@ -67,7 +67,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_hslice_streamf.ipynb
+++ b/templates_notebooks/template_hslice_streamf.ipynb
@@ -67,7 +67,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 1    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 1    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transect.ipynb
+++ b/templates_notebooks/template_transect.ipynb
@@ -58,7 +58,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transect_clim.ipynb
+++ b/templates_notebooks/template_transect_clim.ipynb
@@ -54,7 +54,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transect_hflx.ipynb
+++ b/templates_notebooks/template_transect_hflx.ipynb
@@ -58,7 +58,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transect_hflx_t.ipynb
+++ b/templates_notebooks/template_transect_hflx_t.ipynb
@@ -58,7 +58,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transect_mmean.ipynb
+++ b/templates_notebooks/template_transect_mmean.ipynb
@@ -59,7 +59,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transect_mmean_clim.ipynb
+++ b/templates_notebooks/template_transect_mmean_clim.ipynb
@@ -55,7 +55,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transect_transp.ipynb
+++ b/templates_notebooks/template_transect_transp.ipynb
@@ -58,7 +58,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transect_transp_t.ipynb
+++ b/templates_notebooks/template_transect_transp_t.ipynb
@@ -66,7 +66,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 250  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transect_zmean.ipynb
+++ b/templates_notebooks/template_transect_zmean.ipynb
@@ -55,7 +55,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transect_zmean_clim.ipynb
+++ b/templates_notebooks/template_transect_zmean_clim.ipynb
@@ -55,7 +55,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_dmoc.ipynb
+++ b/templates_notebooks/template_transp_dmoc.ipynb
@@ -59,7 +59,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_dmoc_srfcbflx.ipynb
+++ b/templates_notebooks/template_transp_dmoc_srfcbflx.ipynb
@@ -54,7 +54,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_dmoc_t.ipynb
+++ b/templates_notebooks/template_transp_dmoc_t.ipynb
@@ -59,7 +59,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_dmoc_wdiap.ipynb
+++ b/templates_notebooks/template_transp_dmoc_wdiap.ipynb
@@ -58,7 +58,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_gmhflx.ipynb
+++ b/templates_notebooks/template_transp_gmhflx.ipynb
@@ -59,7 +59,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM     \n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_gzhflx.ipynb
+++ b/templates_notebooks/template_transp_gzhflx.ipynb
@@ -55,7 +55,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM     \n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_hbstreamf.ipynb
+++ b/templates_notebooks/template_transp_hbstreamf.ipynb
@@ -59,7 +59,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_mhflx.ipynb
+++ b/templates_notebooks/template_transp_mhflx.ipynb
@@ -54,7 +54,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 24   # number of total processes\n",
-    "parallel_nthread  = 1   # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 1   # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_mhflx_t.ipynb
+++ b/templates_notebooks/template_transp_mhflx_t.ipynb
@@ -54,7 +54,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_zhflx.ipynb
+++ b/templates_notebooks/template_transp_zhflx.ipynb
@@ -54,7 +54,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_zmoc.ipynb
+++ b/templates_notebooks/template_transp_zmoc.ipynb
@@ -55,7 +55,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_transp_zmoc_t.ipynb
+++ b/templates_notebooks/template_transp_zmoc_t.ipynb
@@ -59,7 +59,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_var_t.ipynb
+++ b/templates_notebooks/template_var_t.ipynb
@@ -59,7 +59,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_vprofile.ipynb
+++ b/templates_notebooks/template_vprofile.ipynb
@@ -62,7 +62,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",

--- a/templates_notebooks/template_vprofile_clim.ipynb
+++ b/templates_notebooks/template_vprofile_clim.ipynb
@@ -62,7 +62,7 @@
     "do_papermill      = False\n",
     "do_parallel       = True\n",
     "parallel_nprc     = 64   # number of total processes\n",
-    "parallel_nthread  = 2    # number of threads per worker --> number worker = parallel_nprc/parallel_nthread\n",
+    "parallel_nthread  = 2    # number of threads per worker --> number of workers then is parallel_nprc/parallel_nthread\n",
     "parallel_tmem     = 256  # max. available RAM\n",
     "\n",
     "#___Mesh Path & Save Path_____________________________________________________________\n",


### PR DESCRIPTION
Papermill does not seem to like "=" signs in comments as described in [this](https://github.com/nteract/papermill/issues/772) issue.

It would come up with the error:

```
Unable to parse line 6 'parallel_nthread  = 2    # number of threads per worker, i.e. number worker = parallel_nprc/parallel_nthread'.
```