### PR TITLE
Workbench

### DIFF
--- a/tripyview/sub_climatology.py
+++ b/tripyview/sub_climatology.py
@@ -173,7 +173,7 @@ def load_climatology(mesh, datapath, vname, mon=None, depth=None, depidx=False,
     #___________________________________________________________________________
     # see if longitude dimension needs to be periodically rolled so it agrees with 
     # the fesom2 mesh focus 
-    lon = data.coords[coord_lon].values
+    lon = data.coords[coord_lon].values.copy()
     if any(lon>mesh.focus+180.0) or any(lon<mesh.focus-180.0):
         # identify rolling index 
         if   any(lon>mesh.focus+180.0):
@@ -425,7 +425,7 @@ def load_climatology_uv(mesh, datapath, vnameu, vnamev, mon=None, depth=None, de
     #___________________________________________________________________________
     # see if longitude dimension needs to be periodically rolled so it agrees with
     # the fesom2 mesh focus
-    lon = data.coords[coord_lon].values
+    lon = data.coords[coord_lon].values.copy()
     if any(lon>mesh.focus+180.0) or any(lon<mesh.focus-180.0):
         # identify rolling index
         if   any(lon>mesh.focus+180.0):

--- a/tripyview/sub_data.py
+++ b/tripyview/sub_data.py
@@ -11,7 +11,6 @@ warnings.filterwarnings("ignore", category=UserWarning, module="distributed.clie
                         message=r".*Large object of size \\d+\\.\\d+ detected in task graph.*")
     
 import xarray as xr
-from xarray.coding.times import encode_cf_datetime
 from xarray.coding.cftimeindex import CFTimeIndex
 
 import pandas as pd
@@ -397,7 +396,7 @@ def load_data_fesom2(mesh,
     if (do_cftime): use_cftime=True
     
     # Build decode_times argument correctly
-    decode_times  = True
+    time_coder    = xr.coders.CFDatetimeCoder(use_cftime=use_cftime)
     decode_coords = False
     if   engine == 'netcdf4' : 
         engine_dict = dict({'engine'        :'netcdf4'     ,
@@ -416,8 +415,7 @@ def load_data_fesom2(mesh,
                                 }})# load normal FESOM2 run file
     engine_dict.update({'combine'       :'by_coords'   , 
                         'decode_coords' :decode_coords , 
-                        'decode_times'  :decode_times  ,  
-                        'use_cftime'    :use_cftime    , })
+                        'decode_times'  :time_coder    , })
                         #'combine'       :'nested', 
                         #'concat_dim'    :'time'
                         #'compat'        :'override', !!! ATTENTION DO NOT USE THAT OPTION it overrides concated years with NaNs!!!

--- a/tripyview/sub_data.py
+++ b/tripyview/sub_data.py
@@ -1432,8 +1432,8 @@ def do_time_arithmetic(data, do_tarithm):
             #___________________________________________________________________
             # annual means 
             if   do_tarithm in ['ymean', 'annual']:
-                # 'AS' = year-start based on original calendar
-                return data.resample(time='AS').mean(keep_attrs=True), str_atim
+                # 'YS' = year-start based on original calendar
+                return data.resample(time='YS').mean(keep_attrs=True), str_atim
                 
             #___________________________________________________________________
             # monthly means 


### PR DESCRIPTION
Fix small errors and warnings in newer environments built with python 3.12

- error of read only climatology
- error with deprecated time resampling
- warning about cftime decoding