### PR TITLE
Transects running NE-->SW now do not crash anymore

### DIFF
--- a/tripyview/sub_transect.py
+++ b/tripyview/sub_transect.py
@@ -154,8 +154,8 @@ def do_analyse_transects(input_transect     ,
         if alpha>=-180 and alpha<=-90:
             transec_lon = np.flip(transec_lon)
             transec_lat = np.flip(transec_lat)
-            sub_transect['e_vec_tot'] = -sub_transect['e_vec_tot']
-            sub_transect['n_vec_tot'] = -sub_transect['n_vec_tot']
+            sub_transect['e_vec_tot'] = [-v for v in sub_transect['e_vec_tot']]
+            sub_transect['n_vec_tot'] = [-v for v in sub_transect['n_vec_tot']]
         del(auxx, auxy, auxn, alpha)
         
         #_______________________________________________________________________


### PR DESCRIPTION
A part of the code used to attempt to flip the transect direction if it is running in that direction. It however assumed numpy arrays. Thus it would crash on lists.

Example for working transect:
```python
input_transect.append([[-28.0,-39.9,-21.0],
                       [ -74.0,-78.8,-58.0],
                       'Works if last point not removed'])
```
Example for previously failing transect
```python
input_transect.append([[-28.0,-21.0,-39.9],
                       [ -74.0,-58.0,-78.8],
                       'Doesnt Work'])
```

Crash used to happen in `template_transect.ipynb` when loading information about edges (`do_analyse_transects`)

<img width="870" height="816" alt="image" src="https://github.com/user-attachments/assets/511e8db1-6f16-4cf2-b009-498c4df66ceb" />

<img width="857" height="832" alt="image" src="https://github.com/user-attachments/assets/ba86e87a-6988-4a33-987b-83ed2a7f0ff1" />
