### PR TITLE
Fix problem with dateline crossing transects when plotting

### DIFF
--- a/templates_notebooks/template_2dmesh.ipynb
+++ b/templates_notebooks/template_2dmesh.ipynb
@@ -142,7 +142,7 @@
     "plt_contl         = False  # label contourline of main colorbar steps \n",
     "do_rescale        = np.array([0,20,25,30,35,40,45,50,55,60,70,80,90,100,110,120,130,140,250])# None # rescale data: None, 'log10', 'slog10', np.array(...)\n",
     "do_lsm            ='fesom' # 'fesom', 'bluemarble', 'etopo', 'stock'\n",
-    "do_mesh           = False, \n",
+    "do_mesh           = False\n",
     "mesh_opt          = dict({'color':'k', 'linewidth':0.10})\n",
     "do_enum           = False  # do enumeration of panels\n",
     "do_reffig         = True   # plot reference fig when doing anomalies \n",

--- a/tripyview/sub_plot.py
+++ b/tripyview/sub_plot.py
@@ -4546,7 +4546,11 @@ def do_data_prepare_vslice(hax_ii, data_ii, box_idx, do_smooth=False, smooth_siz
         # data must be a transect 
         if 'dst' in list(data_ii[box_idx].variables):
             auxlat, auxlon = data_ii[box_idx]['lat'].values[[1,-2]], data_ii[box_idx]['lon'].values[[1,-2]]
-            auxlat, auxlon = np.abs(np.diff(auxlat)), np.abs(np.diff(auxlon))
+            auxlat, auxlon = np.diff(auxlat), np.diff(auxlon)
+            # Handle dateline crossing
+            if   auxlon >  180.0: auxlon = auxlon - 360.0
+            elif auxlon < -180.0: auxlon = auxlon + 360.0
+            auxlat, auxlon = np.abs(auxlat), np.abs(auxlon)
             auxlat, auxlon = auxlat/np.sqrt(auxlat**2+auxlon**2), auxlon/np.sqrt(auxlat**2+auxlon**2)
             angle = np.abs(-np.arctan2(auxlat, auxlon)*180/np.pi)
             if   angle > 80: data_x, str_xlabel = data_ii[box_idx]['lat'].values  , 'Latitude / deg'
@@ -4634,7 +4638,11 @@ def do_data_prepare_vslice(hax_ii, data_ii, box_idx, do_smooth=False, smooth_siz
         # data must be a transect 
         if 'dst' in  list(data_ii.variables):
             auxlat, auxlon = data_ii['lat'].values[[0,-1]], data_ii['lon'].values[[0,1]]
-            auxlat, auxlon = np.abs(np.diff(auxlat)), np.abs(np.diff(auxlon))
+            auxlat, auxlon = np.diff(auxlat), np.diff(auxlon)
+            # Handle dateline crossing
+            if   auxlon >  180.0: auxlon = auxlon - 360.0
+            elif auxlon < -180.0: auxlon = auxlon + 360.0
+            auxlat, auxlon = np.abs(auxlat), np.abs(auxlon)
             auxlat, auxlon = auxlat/np.sqrt(auxlat**2+auxlon**2), auxlon/np.sqrt(auxlat**2+auxlon**2)
             angle = np.abs(-np.arctan2(auxlat, auxlon)*180/np.pi)
             if   angle > 80: data_x, str_xlabel = data_ii['lat'].values  , 'Latitude / deg'


### PR DESCRIPTION
During `plot_vslice` the x axis label is determined in `do_data_prepare_vslice` by looking at the angle of the transect. This decides whether lon/lat/dist is used. With dateline crossing transects the angle determination was incorrect. Should hopefully be fixed now.

See also dd0a1cf where this was implemented among other things for calculating the transect in the first place.